### PR TITLE
added rebar2 backward compatibility

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,7 @@
+case erlang:function_exported(rebar3, main, 1) of
+    true -> % rebar3
+        CONFIG;
+    false -> % rebar 2.x or older
+        []
+end.
+


### PR DESCRIPTION
Recently rebar3 support has been added but it broke some applications which still use old rebar2. For instance MongooseIM is not compiling anymore. In this pull request I added dynamic rebar configuration which enables backward rebar compatibility.