### PR TITLE
Freeze the Port Compiler to a known working commit

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 ]}.
 
 {plugins, [
-  { pc, { git, "git@github.com:blt/port_compiler.git", { branch, "master"}}}
+  { pc, { git, "git@github.com:blt/port_compiler.git", "73c4fc9473ed19c6e4592273cb687855116564b6"}}
 ]}.
 
 {artifacts, ["priv/syslog_drv.so"]}.

--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 ]}.
 
 {plugins, [
-  { pc, { git, "git@github.com:blt/port_compiler.git", "73c4fc9473ed19c6e4592273cb687855116564b6"}}
+  { pc, { git, "git@github.com:blt/port_compiler.git", {ref, "73c4fc9473ed19c6e4592273cb687855116564b6"}}}
 ]}.
 
 {artifacts, ["priv/syslog_drv.so"]}.


### PR DESCRIPTION
Not good to forever leave erlang-syslog pulling from port_compiler master. 

Plug-in dependencies are not locked by rebar3 - reasonable workaround is to explicitly state the hash.

https://github.com/erlang/rebar3/issues/1301 
