### PR TITLE
use tagged version of port_compiler

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,14 +2,14 @@
 %% -*- coding: utf-8 -*-
 
 {erl_opts, [
- debug_info, 
+ debug_info,
  warnings_as_errors,
- warn_untyped_record, 
+ warn_untyped_record,
  {platform_define, "^[0-9]+", namespaced_types}
 ]}.
 
 {plugins, [
-  { pc, { git, "git://github.com/blt/port_compiler.git", {ref, "73c4fc9473ed19c6e4592273cb687855116564b6"}}}
+  { pc, { git, "git://github.com/blt/port_compiler.git", {tag, "v1.5.0"}}}
 ]}.
 
 {artifacts, ["priv/syslog_drv.so"]}.

--- a/src/syslog.app.src
+++ b/src/syslog.app.src
@@ -1,7 +1,7 @@
 {application, syslog,
  [
   {description, "Syslog for erlang"},
-  {vsn, "1.0.3"},
+  {vsn, "1.0.4"},
   {registered, [syslog_sup, syslog]},
   {applications, [
                   kernel,


### PR DESCRIPTION
The port_compiler issues seen in the past seem to be resolved (at least they work for me), so here's a patch which just uses the most recent tag and bumps the version number.  If it's acceptable and merged, making a new tag would be appreciated.  Thanks.