### PR TITLE
update to newest port_compiler

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 ]}.
 
 {plugins, [
-  { pc, { git, "git://github.com/blt/port_compiler.git", {tag, "v1.5.0"}}}
+  { pc, { git, "git://github.com/blt/port_compiler.git", {tag, "1.6.0"}}}
 ]}.
 
 {artifacts, ["priv/syslog_drv.so"]}.

--- a/src/syslog.app.src
+++ b/src/syslog.app.src
@@ -1,7 +1,7 @@
 {application, syslog,
  [
   {description, "Syslog for erlang"},
-  {vsn, "1.0.4"},
+  {vsn, "1.0.5"},
   {registered, [syslog_sup, syslog]},
   {applications, [
                   kernel,


### PR DESCRIPTION
There was another slight change to the port_compiler (makes the clang generated files optional), so this updates the dependency again.  @Vagabond if you have a chance and feel like merging and creating a tag that would be greatly appreciated.  Thanks!