### PR TITLE
add hex required meta data

### DIFF
--- a/src/syslog.app.src
+++ b/src/syslog.app.src
@@ -1,7 +1,7 @@
 {application, syslog,
  [
   {description, "Syslog for erlang"},
-  {vsn, "1.0.5"},
+  {vsn, "1.0.6"},
   {registered, [syslog_sup, syslog]},
   {applications, [
                   kernel,
@@ -9,5 +9,8 @@
                  ]},
   {mod, { syslog_app, []}},
   {modules, []},
+  {licenses,["BSD"]},
+  {links,[{"Github", "https://github.com/Vagabond/erlang-syslog"}]},
+  {maintainers,["Andrew Thompson"]},
   {env, []}
  ]}.


### PR DESCRIPTION
As we discussed in #30 I've been granted access to the hex package. I released [1.0.5](https://hex.pm/packages/syslog/1.0.5) to hex.

For the later released it's better to commit the hex meta data into `syslog.app.src`

I also bumped the version because I need to make a new release into hex to update those meta data in Hex. I made mistake on the project url in `1.0.5` release to hex :(