### PR TITLE
Update port_compiler tag

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 ]}.
 
 {plugins, [
-  { pc, { git, "git://github.com/blt/port_compiler.git", {tag, "1.6.0"}}}
+  { pc, { git, "git://github.com/blt/port_compiler.git", {tag, "v1.6.0"}}}
 ]}.
 
 {artifacts, ["priv/syslog_drv.so"]}.

--- a/src/syslog.app.src
+++ b/src/syslog.app.src
@@ -1,7 +1,7 @@
 {application, syslog,
  [
   {description, "Syslog for erlang"},
-  {vsn, "1.0.5"},
+  {vsn, "1.0.6"},
   {registered, [syslog_sup, syslog]},
   {applications, [
                   kernel,
@@ -9,5 +9,8 @@
                  ]},
   {mod, { syslog_app, []}},
   {modules, []},
+  {licenses,["BSD"]},
+  {links,[{"Github", "https://github.com/Vagabond/erlang-syslog"}]},
+  {maintainers,["Andrew Thompson"]},
   {env, []}
  ]}.


### PR DESCRIPTION
For some reason @blt has decided today to change the tags and add `v` in front of all tags. removing the tag causes the new builds to fail 😞 


I'll also make a release to hex