### PR TITLE
Fix compilation when used as a dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,9 +8,7 @@
  {platform_define, "^[0-9]+", namespaced_types}
 ]}.
 
-{plugins, [
-  { pc, { git, "git://github.com/blt/port_compiler.git", {tag, "1.6.0"}}}
-]}.
+{plugins, [pc]}.
 
 {artifacts, ["priv/syslog_drv.so"]}.
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,7 +1,0 @@
-case erlang:function_exported(rebar3, main, 1) of
-    true -> % rebar3
-        CONFIG;
-    false -> % rebar 2.x or older
-        []
-end.
-


### PR DESCRIPTION
When used as a dependency of ex_syslogger, the syslog_drv.so driver was not compiled by rebar3 (> 3.6.2) until I removed the rebar2 compatibility script.

> Generated ex_syslogger app
=SUPERVISOR REPORT==== 27-Mar-2020::20:15:08.440659 ===
    supervisor: {local,'Elixir.Logger.Supervisor'}
    errorContext: start_error
    reason: {'EXIT',
             {{badmatch,
               {error,
                {{{case_clause,
                   {'EXIT',
                    {badarg,
                     [{erlang,binary_to_term,[[]],[]},
                      {syslog,open,3,
                       [{file,
                         "ex_syslogger/deps/syslog/src/syslog.erl"},
                        {line,110}]},
                      {'Elixir.ExSyslogger',init,1,
                       [{file,"lib/ex_syslogger.ex"},{line,171}]},
                      {gen_event,server_add_handler,4,
                       [{file,"gen_event.erl"},{line,473}]},
                      {gen_event,handle_msg,6,
                       [{file,"gen_event.erl"},{line,318}]},
                      {proc_lib,init_p_do_apply,3,
                       [{file,"proc_lib.erl"},{line,249}]}]}}},
                  [{'Elixir.Logger.Watcher',init,1,
                    [{file,"lib/logger/watcher.ex"},{line,28}]},
                   {gen_server,init_it,2,[{file,"gen_server.erl"},{line,374}]},
                   {gen_server,init_it,6,[{file,"gen_server.erl"},{line,342}]},
                   {proc_lib,init_p_do_apply,3,
                    [{file,"proc_lib.erl"},{line,249}]}]},
                 {child,undefined,
                  {'Elixir.Logger.WatcherSupervisor',
                   {'Elixir.Logger',
                    {'Elixir.ExSyslogger',ex_syslogger_error}}},
                  {'Elixir.Logger.Watcher',start_link,
                   [{'Elixir.Logger',
                     {'Elixir.ExSyslogger',ex_syslogger_error},
                     {'Elixir.ExSyslogger',ex_syslogger_error}}]},
                  transient,5000,worker,
                  ['Elixir.Logger.Watcher']}}}},
              [{'Elixir.Logger.WatcherSupervisor','-start_link/1-fun-0-',2,
                [{file,"lib/logger/watcher_supervisor.ex"},{line,14}]},
               {'Elixir.Enum','-reduce/3-lists^foldl/2-0-',3,
                [{file,"lib/enum.ex"},{line,1925}]},
               {'Elixir.Logger.WatcherSupervisor',start_link,1,
                [{file,"lib/logger/watcher_supervisor.ex"},{line,13}]},
               {supervisor,do_start_child_i,3,
                [{file,"supervisor.erl"},{line,379}]},
               {supervisor,do_start_child,2,
                [{file,"supervisor.erl"},{line,365}]},
               {supervisor,'-start_children/2-fun-0-',3,
                [{file,"supervisor.erl"},{line,349}]},
               {supervisor,children_map,4,
                [{file,"supervisor.erl"},{line,1157}]},
               {supervisor,init_children,2,
                [{file,"supervisor.erl"},{line,315}]}]}}
    offender: [{pid,undefined},
               {id,'Elixir.Logger.WatcherSupervisor'},
               {mfargs,
                   {'Elixir.Logger.WatcherSupervisor',start_link,
                       [{'Elixir.Logger.Config',handlers,[]}]}},
               {restart_type,permanent},
               {shutdown,infinity},
               {child_type,supervisor}]
=CRASH REPORT==== 27-Mar-2020::20:15:08.439911 ===
  crasher:
    initial call: syslog:init/1
    pid: <0.207.0>
    registered_name: []
    exception exit: "could not load driver syslog_drv: \"dlopen(ex_syslogger/_build/dev/lib/syslog/priv/syslog_drv.so, 2): image not found\""
      in function  gen_server:init_it/6 (gen_server.erl, line 358)
    ancestors: ['Elixir.Logger','Elixir.Logger.Supervisor',<0.201.0>]
    message_queue_len: 0
    messages: []
    links: []
    dictionary: []
    trap_exit: false
    status: running
    heap_size: 610
    stack_size: 27
    reductions: 1623
  neighbours:

=CRASH REPORT==== 27-Mar-2020::20:15:08.440537 ===
  crasher:
    initial call: Elixir.Logger.Watcher:init/1
    pid: <0.206.0>
    registered_name: []
    exception error: no case clause matching
                     {'EXIT',
                         {badarg,
                             [{erlang,binary_to_term,[[]],[]},
                              {syslog,open,3,
                                  [{file,
                                       "ex_syslogger/deps/syslog/src/syslog.erl"},
                                   {line,110}]},
                              {'Elixir.ExSyslogger',init,1,
                                  [{file,"lib/ex_syslogger.ex"},{line,171}]},
                              {gen_event,server_add_handler,4,
                                  [{file,"gen_event.erl"},{line,473}]},
                              {gen_event,handle_msg,6,
                                  [{file,"gen_event.erl"},{line,318}]},
                              {proc_lib,init_p_do_apply,3,
                                  [{file,"proc_lib.erl"},{line,249}]}]}}
      in function  'Elixir.Logger.Watcher':init/1 (lib/logger/watcher.ex, line 28)
      in call from gen_server:init_it/2 (gen_server.erl, line 374)
      in call from gen_server:init_it/6 (gen_server.erl, line 342)
    ancestors: ['Elixir.Logger.WatcherSupervisor',
                  'Elixir.Logger.Supervisor',<0.201.0>]
    message_queue_len: 0
    messages: []
    links: [<0.205.0>,<0.203.0>]
    dictionary: []
    trap_exit: true
    status: running
    heap_size: 987
    stack_size: 27
    reductions: 270
  neighbours:

sh: line 0: exec: syslog_drv: not found
                                       =CRASH REPORT==== 27-Mar-2020::20:15:08.444515 ===
  crasher:
    initial call: application_master:init/4
    pid: <0.200.0>
    registered_name: []
    exception exit: {{shutdown,
                      {failed_to_start_child,
                       'Elixir.Logger.WatcherSupervisor',
                       {'EXIT',
                        {{badmatch,
                          {error,
                           {{{case_clause,
                              {'EXIT',
                               {badarg,
                                [{erlang,binary_to_term,[[]],[]},
                                 {syslog,open,3,
                                  [{file,
                                    "ex_syslogger/deps/syslog/src/syslog.erl"},
                                   {line,110}]},
                                 {'Elixir.ExSyslogger',init,1,
                                  [{file,"lib/ex_syslogger.ex"},{line,171}]},
                                 {gen_event,server_add_handler,4,
                                  [{file,"gen_event.erl"},{line,473}]},
                                 {gen_event,handle_msg,6,
                                  [{file,"gen_event.erl"},{line,318}]},
                                 {proc_lib,init_p_do_apply,3,
                                  [{file,"proc_lib.erl"},{line,249}]}]}}},
                             [{'Elixir.Logger.Watcher',init,1,
                               [{file,"lib/logger/watcher.ex"},{line,28}]},
                              {gen_server,init_it,2,
                               [{file,"gen_server.erl"},{line,374}]},
                              {gen_server,init_it,6,
                               [{file,"gen_server.erl"},{line,342}]},
                              {proc_lib,init_p_do_apply,3,
                               [{file,"proc_lib.erl"},{line,249}]}]},
                            {child,undefined,
                             {'Elixir.Logger.WatcherSupervisor',
                              {'Elixir.Logger',
                               {'Elixir.ExSyslogger',ex_syslogger_error}}},
                             {'Elixir.Logger.Watcher',start_link,
                              [{'Elixir.Logger',
                                {'Elixir.ExSyslogger',ex_syslogger_error},
                                {'Elixir.ExSyslogger',ex_syslogger_error}}]},
                             transient,5000,worker,
                             ['Elixir.Logger.Watcher']}}}},
                         [{'Elixir.Logger.WatcherSupervisor',
                           '-start_link/1-fun-0-',2,
                           [{file,"lib/logger/watcher_supervisor.ex"},
                            {line,14}]},
                          {'Elixir.Enum','-reduce/3-lists^foldl/2-0-',3,
                           [{file,"lib/enum.ex"},{line,1925}]},
                          {'Elixir.Logger.WatcherSupervisor',start_link,1,
                           [{file,"lib/logger/watcher_supervisor.ex"},
                            {line,13}]},
                          {supervisor,do_start_child_i,3,
                           [{file,"supervisor.erl"},{line,379}]},
                          {supervisor,do_start_child,2,
                           [{file,"supervisor.erl"},{line,365}]},
                          {supervisor,'-start_children/2-fun-0-',3,
                           [{file,"supervisor.erl"},{line,349}]},
                          {supervisor,children_map,4,
                           [{file,"supervisor.erl"},{line,1157}]},
                          {supervisor,init_children,2,
                           [{file,"supervisor.erl"},{line,315}]}]}}}},
                     {'Elixir.Logger.App',start,[normal,[]]}}
      in function  application_master:init/4 (application_master.erl, line 138)
    ancestors: [<0.199.0>]
    message_queue_len: 1
    messages: [{'EXIT',<0.201.0>,normal}]
    links: [<0.199.0>,<0.42.0>]
    dictionary: []
    trap_exit: true
    status: running
    heap_size: 1598
    stack_size: 27
    reductions: 180
  neighbours:

=INFO REPORT==== 27-Mar-2020::20:15:08.461529 ===
    application: logger
    exited: {{shutdown,
              {failed_to_start_child,'Elixir.Logger.WatcherSupervisor',
               {'EXIT',
                {{badmatch,
                  {error,
                   {{{case_clause,
                      {'EXIT',
                       {badarg,
                        [{erlang,binary_to_term,[[]],[]},
                         {syslog,open,3,
                          [{file,
                            "ex_syslogger/deps/syslog/src/syslog.erl"},
                           {line,110}]},
                         {'Elixir.ExSyslogger',init,1,
                          [{file,"lib/ex_syslogger.ex"},{line,171}]},
                         {gen_event,server_add_handler,4,
                          [{file,"gen_event.erl"},{line,473}]},
                         {gen_event,handle_msg,6,
                          [{file,"gen_event.erl"},{line,318}]},
                         {proc_lib,init_p_do_apply,3,
                          [{file,"proc_lib.erl"},{line,249}]}]}}},
                     [{'Elixir.Logger.Watcher',init,1,
                       [{file,"lib/logger/watcher.ex"},{line,28}]},
                      {gen_server,init_it,2,
                       [{file,"gen_server.erl"},{line,374}]},
                      {gen_server,init_it,6,
                       [{file,"gen_server.erl"},{line,342}]},
                      {proc_lib,init_p_do_apply,3,
                       [{file,"proc_lib.erl"},{line,249}]}]},
                    {child,undefined,
                     {'Elixir.Logger.WatcherSupervisor',
                      {'Elixir.Logger',
                       {'Elixir.ExSyslogger',ex_syslogger_error}}},
                     {'Elixir.Logger.Watcher',start_link,
                      [{'Elixir.Logger',
                        {'Elixir.ExSyslogger',ex_syslogger_error},
                        {'Elixir.ExSyslogg** (Mix) Could not start application logger: Logger.App.start(:normal, []) returned an error: shutdown: failed to start child: Logger.WatcherSupervisor
    ** (EXIT) an exception was raised:
        ** (MatchError) no match of right hand side value: {:error, {{{:case_clause, {:EXIT, {:badarg, [{:erlang, :binary_to_term, [[]], []}, {:syslog, :open, 3, [file: 'ex_syslogger/deps/syslog/src/syslog.erl', line: 110]}, {ExSyslogger, :init, 1, [file: 'lib/ex_syslogger.ex', line: 171]}, {:gen_event, :server_add_handler, 4, [file: 'gen_event.erl', line: 473]}, {:gen_event, :handle_msg, 6, [file: 'gen_event.erl', line: 318]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}]}}}, [{Logger.Watcher, :init, 1, [file: 'lib/logger/watcher.ex', line: 28]}, {:gen_server, :init_it, 2, [file: 'gen_server.erl', line: 374]}, {:gen_server, :init_it, 6, [file: 'gen_server.erl', line: 342]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}]}, {:child, :undefined, {Logger.WatcherSupervisor, {Logger, {ExSyslogger, :ex_syslogger_error}}}, {Logger.Watcher, :start_link, [{Logger, {ExSyslogger, :ex_syslogger_error}, {ExSyslogger, :ex_syslogger_error}}]}, :transient, 5000, :worker, [Logger.Watcher]}}}
            (logger) lib/logger/watcher_supervisor.ex:14: anonymous fn/2 in Logger.WatcherSupervisor.start_link/1
            (elixir) lib/enum.ex:1925: Enum."-reduce/3-lists^foldl/2-0-"/3
            (logger) lib/logger/watcher_supervisor.ex:13: Logger.WatcherSupervisor.start_link/1
            (stdlib) supervisor.erl:379: :supervisor.do_start_child_i/3
            (stdlib) supervisor.erl:365: :supervisor.do_start_child/2
            (stdlib) supervisor.erl:349: anonymous fn/3 in :supervisor.start_children/2
            (stdlib) supervisor.erl:1157: :supervisor.children_map/4
            (stdlib) supervisor.erl:315: :supervisor.init_children/2
er',ex_syslogger_error}}]},
                     transient,5000,worker,
                     ['Elixir.Logger.Watcher']}}}},
                 [{'Elixir.Logger.WatcherSupervisor','-start_link/1-fun-0-',
                   2,
                   [{file,"lib/logger/watcher_supervisor.ex"},{line,14}]},
                  {'Elixir.Enum','-reduce/3-lists^foldl/2-0-',3,
                   [{file,"lib/enum.ex"},{line,1925}]},
                  {'Elixir.Logger.WatcherSupervisor',start_link,1,
                   [{file,"lib/logger/watcher_supervisor.ex"},{line,13}]},
                  {supervisor,do_start_child_i,3,
                   [{file,"supervisor.erl"},{line,379}]},
                  {supervisor,do_start_child,2,
                   [{file,"supervisor.erl"},{line,365}]},
                  {supervisor,'-start_children/2-fun-0-',3,
                   [{file,"supervisor.erl"},{line,349}]},
                  {supervisor,children_map,4,
                   [{file,"supervisor.erl"},{line,1157}]},
                  {supervisor,init_children,2,
                   [{file,"supervisor.erl"},{line,315}]}]}}}},
             {'Elixir.Logger.App',start,[normal,[]]}}
    type: temporary